### PR TITLE
fix: follow directories

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -349,13 +349,9 @@ func fileExists(sourceFS fs.FS, filePath string) bool {
 
 // Returns if d is a README file.
 func isIgnoredFile(d fs.DirEntry) bool {
-	if d.IsDir() {
-		return true
-	}
-
 	switch d.Name() {
 	case "README.md", "readme.md", "LICENSE.md", "license.md":
-		return true
+		return !d.IsDir()
 	default:
 		return false
 	}


### PR DESCRIPTION
4820dc18ae78516bab4e90ac6f0ed06a4f2301d9 had wrong logic to determine if we need to ignore a file.

This caused directories to be ignored, and stop recursing over them. Which would result in entire directories to not be parsed.